### PR TITLE
Tidying works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["algorithms", "api-bindings"]
 documentation = "https://mthh.github.io/sfcgal-rs/sfcgal/"
 
 [dependencies]
-sfcgal-sys = "0.2.0"
-failure = "^0.1"
-libc = "0.2.48"
+sfcgal-sys = "0.2"
+failure = "0.1"
+libc = "0.2"
 geo-types = "0.4"
-enum-primitive-derive = "^0.1"
-num-traits = "^0.1"
+enum-primitive-derive = "0.1"
+num-traits = "0.1"
 approx = "0.3"
 geojson = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://mthh.github.io/sfcgal-rs/sfcgal/"
 
 [dependencies]
 sfcgal-sys = "0.2"
-failure = "0.1"
+anyhow = "1.0"
 libc = "0.2"
 geo-types = "0.4"
 enum-primitive-derive = "0.1"

--- a/src/conversion/coords.rs
+++ b/src/conversion/coords.rs
@@ -17,7 +17,7 @@ use sfcgal_sys::{
     sfcgal_solid_create_from_exterior_shell, sfcgal_solid_num_shells, sfcgal_solid_shell_n,
     sfcgal_triangle_create, sfcgal_triangle_set_vertex, sfcgal_triangle_vertex,
     sfcgal_triangulated_surface_add_triangle, sfcgal_triangulated_surface_create,
-    sfcgal_triangulated_surface_num_triangles, sfcgal_triangulated_surface_triangle_n,
+    sfcgal_triangulated_surface_num_triangles, sfcgal_triangulated_surface_triangle_n, size_t,
 };
 
 pub trait CoordType {}
@@ -297,7 +297,7 @@ macro_rules! sfcgal_line_to_coords {
     ($geom: expr, $type_pt: ident) => {{
         let g = $geom;
         let n_points = unsafe { sfcgal_linestring_num_points(g) };
-        let mut v_points = Vec::with_capacity(n_points);
+        let mut v_points = Vec::with_capacity(n_points as usize);
         for i in 0..n_points {
             let pt_sfcgal = unsafe { sfcgal_linestring_point_n(g, i) };
             // check_null_geom(g)?;
@@ -312,7 +312,7 @@ macro_rules! sfcgal_polygon_to_coords {
         let g = $geom;
         let nrings = unsafe { sfcgal_polygon_num_interior_rings(g) };
         let exterior_sfcgal = unsafe { sfcgal_polygon_exterior_ring(g) };
-        let mut rings = Vec::with_capacity(nrings + 1usize);
+        let mut rings = Vec::with_capacity(nrings as usize + 1);
         rings.push(sfcgal_line_to_coords!(exterior_sfcgal, $type_pt));
         for ix in 0..nrings {
             let line_sfcgal = unsafe { sfcgal_polygon_interior_ring_n(g, ix) };
@@ -340,7 +340,7 @@ macro_rules! sfcgal_polyhedral_surface_to_coords {
     ($geom: expr, $type_pt: ident) => {{
         let g = $geom;
         let ngeoms = unsafe { sfcgal_polyhedral_surface_num_polygons(g) };
-        let mut polygons = Vec::with_capacity(ngeoms);
+        let mut polygons = Vec::with_capacity(ngeoms as usize);
         for ix in 0..ngeoms {
             let poly = unsafe { sfcgal_polyhedral_surface_polygon_n(g, ix) };
             polygons.push(sfcgal_polygon_to_coords!(poly, $type_pt));
@@ -350,11 +350,11 @@ macro_rules! sfcgal_polyhedral_surface_to_coords {
 }
 
 fn get_nb_geometry(geom: *const sfcgal_geometry_t) -> usize {
-    unsafe { sfcgal_geometry_collection_num_geometries(geom) }
+    unsafe { sfcgal_geometry_collection_num_geometries(geom) as usize }
 }
 
 fn get_geom_at_index(geom: *const sfcgal_geometry_t, ix: usize) -> *const sfcgal_geometry_t {
-    unsafe { sfcgal_geometry_collection_geometry_n(geom, ix) }
+    unsafe { sfcgal_geometry_collection_geometry_n(geom, ix as size_t) }
 }
 
 /// Convert a [`SFCGeometry`], given it's internal [`GeomType`], to the corresponding [`CoordSeq`]
@@ -416,7 +416,7 @@ impl ToCoordinates for SFCGeometry {
                     let inner_geom = unsafe {
                         // Todo : document what we are doing that
                         SFCGeometry::new_from_raw(
-                            sfcgal_geometry_collection_geometry_n(geom, ix)
+                            sfcgal_geometry_collection_geometry_n(geom, ix as size_t)
                                 as *mut sfcgal_geometry_t,
                             false,
                         )?
@@ -433,7 +433,7 @@ impl ToCoordinates for SFCGeometry {
             GeomType::Triangulatedsurface => {
                 let geom = unsafe { self.c_geom.as_ref() };
                 let ngeoms = unsafe { sfcgal_triangulated_surface_num_triangles(geom) };
-                let mut triangles = Vec::with_capacity(ngeoms);
+                let mut triangles = Vec::with_capacity(ngeoms as usize);
                 for ix in 0..ngeoms {
                     let triangle = unsafe { sfcgal_triangulated_surface_triangle_n(geom, ix) };
                     triangles.push(sfcgal_triangle_to_coords!(triangle, T));
@@ -446,7 +446,7 @@ impl ToCoordinates for SFCGeometry {
             GeomType::Solid => {
                 let geom = unsafe { self.c_geom.as_ref() };
                 let ngeoms = unsafe { sfcgal_solid_num_shells(geom) };
-                let mut polyhedres = Vec::with_capacity(ngeoms);
+                let mut polyhedres = Vec::with_capacity(ngeoms as usize);
                 for ix in 0..ngeoms {
                     let poly = unsafe { sfcgal_solid_shell_n(geom, ix) };
                     polyhedres.push(sfcgal_polyhedral_surface_to_coords!(poly, T));
@@ -460,7 +460,7 @@ impl ToCoordinates for SFCGeometry {
                 for ix_geom in 0..n_solides {
                     let solid = get_geom_at_index(geom_ms, ix_geom);
                     let n_shell = unsafe { sfcgal_solid_num_shells(solid) };
-                    let mut polyhedres = Vec::with_capacity(n_shell);
+                    let mut polyhedres = Vec::with_capacity(n_shell as usize);
                     for ix in 0..n_shell {
                         let poly = unsafe { sfcgal_solid_shell_n(solid, ix) };
                         polyhedres.push(sfcgal_polyhedral_surface_to_coords!(poly, T));

--- a/src/conversion/coords.rs
+++ b/src/conversion/coords.rs
@@ -13,9 +13,8 @@ use sfcgal_sys::{
     sfcgal_polygon_exterior_ring, sfcgal_polygon_interior_ring_n,
     sfcgal_polygon_num_interior_rings, sfcgal_polyhedral_surface_add_polygon,
     sfcgal_polyhedral_surface_create, sfcgal_polyhedral_surface_num_polygons,
-    sfcgal_polyhedral_surface_polygon_n, sfcgal_solid_create,
-    sfcgal_solid_create_from_exterior_shell, sfcgal_solid_add_interior_shell,
-    sfcgal_solid_num_shells, sfcgal_solid_shell_n,
+    sfcgal_polyhedral_surface_polygon_n, sfcgal_solid_add_interior_shell, sfcgal_solid_create,
+    sfcgal_solid_create_from_exterior_shell, sfcgal_solid_num_shells, sfcgal_solid_shell_n,
     sfcgal_triangle_create, sfcgal_triangle_set_vertex, sfcgal_triangle_vertex,
     sfcgal_triangulated_surface_add_triangle, sfcgal_triangulated_surface_create,
     sfcgal_triangulated_surface_num_triangles, sfcgal_triangulated_surface_triangle_n,
@@ -266,15 +265,19 @@ impl<T: ToSFCGALGeom + CoordType> ToSFCGAL for CoordSeq<T> {
                 } else {
                     let exterior = coords_polyhedralsurface_to_sfcgal(&polyhedres[0])?;
                     let r_solid = unsafe { sfcgal_solid_create_from_exterior_shell(exterior) };
-                    polyhedres.into_iter().skip(1).map(|poly| {
-                        unsafe {
-                            sfcgal_solid_add_interior_shell(
-                                r_solid,
-                                coords_polyhedralsurface_to_sfcgal(poly)?,
-                            )
-                        };
-                        Ok(())
-                    }).collect::<Result<Vec<_>>>()?;
+                    polyhedres
+                        .into_iter()
+                        .skip(1)
+                        .map(|poly| {
+                            unsafe {
+                                sfcgal_solid_add_interior_shell(
+                                    r_solid,
+                                    coords_polyhedralsurface_to_sfcgal(poly)?,
+                                )
+                            };
+                            Ok(())
+                        })
+                        .collect::<Result<Vec<_>>>()?;
                     r_solid
                 };
                 unsafe { SFCGeometry::new_from_raw(out_solid, true) }
@@ -664,20 +667,20 @@ mod tests {
     #[test]
     fn solid_with_interior_shell_3d_sfcgal_to_coordinates() {
         let input_wkt = "SOLID((\
-        ((0.0 0.0 0.0,0.0 1.0 0.0,1.0 1.0 0.0,1.0 0.0 0.0,0.0 0.0 0.0)),\
-        ((1.0 0.0 0.0,1.0 1.0 0.0,1.0 1.0 1.0,1.0 0.0 1.0,1.0 0.0 0.0)),\
-        ((0.0 1.0 0.0,0.0 1.0 1.0,1.0 1.0 1.0,1.0 1.0 0.0,0.0 1.0 0.0)),\
-        ((0.0 0.0 1.0,0.0 1.0 1.0,0.0 1.0 0.0,0.0 0.0 0.0,0.0 0.0 1.0)),\
-        ((1.0 0.0 1.0,1.0 1.0 1.0,0.0 1.0 1.0,0.0 0.0 1.0,1.0 0.0 1.0)),\
-        ((1.0 0.0 0.0,1.0 0.0 1.0,0.0 0.0 1.0,0.0 0.0 0.0,1.0 0.0 0.0))\
-        ),(\
-        ((0.0 0.0 0.0,0.0 0.5 0.0,0.5 0.5 0.0,0.5 0.0 0.0,0.0 0.0 0.0)),\
-        ((0.5 0.0 0.0,0.5 0.5 0.0,0.5 0.5 0.5,0.5 0.0 0.5,0.5 0.0 0.0)),\
-        ((0.0 0.5 0.0,0.0 0.5 0.5,0.5 0.5 0.5,0.5 0.5 0.0,0.0 0.5 0.0)),\
-        ((0.0 0.0 0.5,0.0 0.5 0.5,0.0 0.5 0.0,0.0 0.0 0.0,0.0 0.0 0.5)),\
-        ((0.5 0.0 0.5,0.5 0.5 0.5,0.0 0.5 0.5,0.0 0.0 0.5,0.5 0.0 0.5)),\
-        ((0.5 0.0 0.0,0.5 0.0 0.5,0.0 0.0 0.5,0.0 0.0 0.0,0.5 0.0 0.0))\
-        ))";
+                         ((0.0 0.0 0.0,0.0 1.0 0.0,1.0 1.0 0.0,1.0 0.0 0.0,0.0 0.0 0.0)),\
+                         ((1.0 0.0 0.0,1.0 1.0 0.0,1.0 1.0 1.0,1.0 0.0 1.0,1.0 0.0 0.0)),\
+                         ((0.0 1.0 0.0,0.0 1.0 1.0,1.0 1.0 1.0,1.0 1.0 0.0,0.0 1.0 0.0)),\
+                         ((0.0 0.0 1.0,0.0 1.0 1.0,0.0 1.0 0.0,0.0 0.0 0.0,0.0 0.0 1.0)),\
+                         ((1.0 0.0 1.0,1.0 1.0 1.0,0.0 1.0 1.0,0.0 0.0 1.0,1.0 0.0 1.0)),\
+                         ((1.0 0.0 0.0,1.0 0.0 1.0,0.0 0.0 1.0,0.0 0.0 0.0,1.0 0.0 0.0))\
+                         ),(\
+                         ((0.0 0.0 0.0,0.0 0.5 0.0,0.5 0.5 0.0,0.5 0.0 0.0,0.0 0.0 0.0)),\
+                         ((0.5 0.0 0.0,0.5 0.5 0.0,0.5 0.5 0.5,0.5 0.0 0.5,0.5 0.0 0.0)),\
+                         ((0.0 0.5 0.0,0.0 0.5 0.5,0.5 0.5 0.5,0.5 0.5 0.0,0.0 0.5 0.0)),\
+                         ((0.0 0.0 0.5,0.0 0.5 0.5,0.0 0.5 0.0,0.0 0.0 0.0,0.0 0.0 0.5)),\
+                         ((0.5 0.0 0.5,0.5 0.5 0.5,0.0 0.5 0.5,0.0 0.0 0.5,0.5 0.0 0.5)),\
+                         ((0.5 0.0 0.0,0.5 0.0 0.5,0.0 0.0 0.5,0.0 0.0 0.0,0.5 0.0 0.0))\
+                         ))";
         let cube = SFCGeometry::new(input_wkt).unwrap();
         let coords: CoordSeq<Point3d> = cube.to_coordinates().unwrap();
         if let CoordSeq::Solid(ref polys) = coords {

--- a/src/conversion/geojson.rs
+++ b/src/conversion/geojson.rs
@@ -1,6 +1,6 @@
 use crate::conversion::coords::{CoordType, FromSFCGALGeom, ToSFCGALGeom};
 use crate::{CoordSeq, Point2d, Point3d, Result, SFCGeometry, ToCoordinates, ToSFCGAL};
-use failure::Error;
+use anyhow::Error;
 use geojson::Value as GeometryValue;
 
 /// Conversion from [`SFCGeometry`] (implemented on [geo-types](https://docs.rs/geo-types/) geometries)

--- a/src/conversion/geojson.rs
+++ b/src/conversion/geojson.rs
@@ -335,13 +335,14 @@ mod tests {
     #[test]
     fn multiline_2d_sfcgal_to_geojson_to_sfcgal() {
         let input_wkt = "MULTILINESTRING(\
-            (-0.0 -0.0,0.5 0.5),\
-            (1.0 -0.0,0.5 0.5),\
-            (1.0 1.0,0.5 0.5),\
-            (-0.0 1.0,0.5 0.5))";
+                         (-0.0 -0.0,0.5 0.5),\
+                         (1.0 -0.0,0.5 0.5),\
+                         (1.0 1.0,0.5 0.5),\
+                         (-0.0 1.0,0.5 0.5))";
         let multiline_sfcgal = SFCGeometry::new(input_wkt).unwrap();
         let multiline_geojson = multiline_sfcgal.to_geojson::<Point2d>().unwrap();
-        let multiline_sfcgal_new = SFCGeometry::from_geojson::<Point2d>(&multiline_geojson).unwrap();
+        let multiline_sfcgal_new =
+            SFCGeometry::from_geojson::<Point2d>(&multiline_geojson).unwrap();
         assert_eq!(
             multiline_sfcgal.to_wkt_decim(1).unwrap(),
             multiline_sfcgal_new.to_wkt_decim(1).unwrap()
@@ -356,13 +357,14 @@ mod tests {
     #[test]
     fn multiline_3d_sfcgal_to_geojson_to_sfcgal() {
         let input_wkt = "MULTILINESTRING(\
-            (-0.0 -0.0 1.3,0.5 0.5 1.3),\
-            (1.0 -0.0 1.3,0.5 0.5 1.3),\
-            (1.0 1.0 1.3,0.5 0.5 1.3),\
-            (-0.0 1.0 1.3,0.5 0.5 1.3))";
+                         (-0.0 -0.0 1.3,0.5 0.5 1.3),\
+                         (1.0 -0.0 1.3,0.5 0.5 1.3),\
+                         (1.0 1.0 1.3,0.5 0.5 1.3),\
+                         (-0.0 1.0 1.3,0.5 0.5 1.3))";
         let multiline_sfcgal = SFCGeometry::new(input_wkt).unwrap();
         let multiline_geojson = multiline_sfcgal.to_geojson::<Point3d>().unwrap();
-        let multiline_sfcgal_new = SFCGeometry::from_geojson::<Point3d>(&multiline_geojson).unwrap();
+        let multiline_sfcgal_new =
+            SFCGeometry::from_geojson::<Point3d>(&multiline_geojson).unwrap();
         assert_eq!(
             multiline_sfcgal.to_wkt_decim(1).unwrap(),
             multiline_sfcgal_new.to_wkt_decim(1).unwrap()
@@ -413,7 +415,8 @@ mod tests {
         let input_wkt = "MULTIPOLYGON(((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 0.0)))";
         let multipolyg_sfcgal = SFCGeometry::new(input_wkt).unwrap();
         let multipolyg_geojson = multipolyg_sfcgal.to_geojson::<Point2d>().unwrap();
-        let multipolyg_sfcgal_new = SFCGeometry::from_geojson::<Point2d>(&multipolyg_geojson).unwrap();
+        let multipolyg_sfcgal_new =
+            SFCGeometry::from_geojson::<Point2d>(&multipolyg_geojson).unwrap();
         assert_eq!(
             multipolyg_sfcgal.to_wkt_decim(1).unwrap(),
             multipolyg_sfcgal_new.to_wkt_decim(1).unwrap()
@@ -424,7 +427,8 @@ mod tests {
         let input_wkt = "MULTIPOLYGON(((0.0 0.0 2.0, 1.0 0.0 2.0, 1.0 1.0 2.0, 0.0 0.0 2.0)))";
         let multipolyg_sfcgal = SFCGeometry::new(input_wkt).unwrap();
         let multipolyg_geojson = multipolyg_sfcgal.to_geojson::<Point3d>().unwrap();
-        let multipolyg_sfcgal_new = SFCGeometry::from_geojson::<Point3d>(&multipolyg_geojson).unwrap();
+        let multipolyg_sfcgal_new =
+            SFCGeometry::from_geojson::<Point3d>(&multipolyg_geojson).unwrap();
         assert_eq!(
             multipolyg_sfcgal.to_wkt_decim(1).unwrap(),
             multipolyg_sfcgal_new.to_wkt_decim(1).unwrap()
@@ -441,7 +445,8 @@ mod tests {
         let input_wkt = "GEOMETRYCOLLECTION(POINT(1.0 1.0),LINESTRING(10.0 1.0,1.0 2.0))";
         let multipolyg_sfcgal = SFCGeometry::new(input_wkt).unwrap();
         let multipolyg_geojson = multipolyg_sfcgal.to_geojson::<Point2d>().unwrap();
-        let multipolyg_sfcgal_new = SFCGeometry::from_geojson::<Point2d>(&multipolyg_geojson).unwrap();
+        let multipolyg_sfcgal_new =
+            SFCGeometry::from_geojson::<Point2d>(&multipolyg_geojson).unwrap();
         assert_eq!(
             multipolyg_sfcgal.to_wkt_decim(1).unwrap(),
             multipolyg_sfcgal_new.to_wkt_decim(1).unwrap()
@@ -449,10 +454,12 @@ mod tests {
     }
     #[test]
     fn geomcollection_3d_sfcgal_to_geojson_to_sfcgal() {
-        let input_wkt = "GEOMETRYCOLLECTION(POINT(1.0 1.0 4.0),LINESTRING(10.0 1.0 4.0,1.0 2.0 4.0))";
+        let input_wkt =
+            "GEOMETRYCOLLECTION(POINT(1.0 1.0 4.0),LINESTRING(10.0 1.0 4.0,1.0 2.0 4.0))";
         let multipolyg_sfcgal = SFCGeometry::new(input_wkt).unwrap();
         let multipolyg_geojson = multipolyg_sfcgal.to_geojson::<Point3d>().unwrap();
-        let multipolyg_sfcgal_new = SFCGeometry::from_geojson::<Point3d>(&multipolyg_geojson).unwrap();
+        let multipolyg_sfcgal_new =
+            SFCGeometry::from_geojson::<Point3d>(&multipolyg_geojson).unwrap();
         assert_eq!(
             multipolyg_sfcgal.to_wkt_decim(1).unwrap(),
             multipolyg_sfcgal_new.to_wkt_decim(1).unwrap()

--- a/src/conversion/geojson.rs
+++ b/src/conversion/geojson.rs
@@ -1,5 +1,7 @@
-use crate::conversion::coords::{CoordType, FromSFCGALGeom, ToSFCGALGeom};
-use crate::{CoordSeq, Point2d, Point3d, Result, SFCGeometry, ToCoordinates, ToSFCGAL};
+use crate::{
+    conversion::coords::{CoordType, FromSFCGALGeom, ToSFCGALGeom},
+    CoordSeq, Point2d, Point3d, Result, SFCGeometry, ToCoordinates, ToSFCGAL,
+};
 use anyhow::Error;
 use geojson::Value as GeometryValue;
 

--- a/src/conversion/geotypes.rs
+++ b/src/conversion/geotypes.rs
@@ -129,7 +129,7 @@ impl TryInto<geo_types::Geometry<f64>> for SFCGeometry {
             GeomType::Multilinestring => {
                 let ngeoms =
                     unsafe { sfcgal_geometry_collection_num_geometries(self.c_geom.as_ref()) };
-                let mut lines = Vec::with_capacity(ngeoms);
+                let mut lines = Vec::with_capacity(ngeoms as usize);
                 for i in 0..ngeoms {
                     let geom =
                         unsafe { sfcgal_geometry_collection_geometry_n(self.c_geom.as_ref(), i) };
@@ -143,7 +143,7 @@ impl TryInto<geo_types::Geometry<f64>> for SFCGeometry {
                 let nrings = unsafe { sfcgal_polygon_num_interior_rings(self.c_geom.as_ref()) };
                 let exterior_sfcgal = unsafe { sfcgal_polygon_exterior_ring(self.c_geom.as_ref()) };
                 let exterior_geo = geo_line_from_sfcgal(exterior_sfcgal)?;
-                let mut interiors_geo = Vec::with_capacity(nrings);
+                let mut interiors_geo = Vec::with_capacity(nrings as usize);
                 for i in 0..nrings {
                     let line_sfcgal =
                         unsafe { sfcgal_polygon_interior_ring_n(self.c_geom.as_ref(), i) };
@@ -158,14 +158,14 @@ impl TryInto<geo_types::Geometry<f64>> for SFCGeometry {
             GeomType::Multipolygon => {
                 let ngeoms =
                     unsafe { sfcgal_geometry_collection_num_geometries(self.c_geom.as_ref()) };
-                let mut vec_polygons = Vec::with_capacity(ngeoms);
+                let mut vec_polygons = Vec::with_capacity(ngeoms as usize);
                 for i in 0..ngeoms {
                     let _polyg =
                         unsafe { sfcgal_geometry_collection_geometry_n(self.c_geom.as_ref(), i) };
                     let nrings = unsafe { sfcgal_polygon_num_interior_rings(_polyg) };
                     let exterior_sfcgal = unsafe { sfcgal_polygon_exterior_ring(_polyg) };
                     let exterior_geo = geo_line_from_sfcgal(exterior_sfcgal)?;
-                    let mut interiors_geo = Vec::with_capacity(nrings);
+                    let mut interiors_geo = Vec::with_capacity(nrings as usize);
                     for j in 0..nrings {
                         let line_sfcgal = unsafe { sfcgal_polygon_interior_ring_n(_polyg, j) };
                         interiors_geo.push(geo_line_from_sfcgal(line_sfcgal)?);
@@ -201,7 +201,7 @@ fn geo_line_from_sfcgal(
     sfcgal_geom: *const sfcgal_geometry_t,
 ) -> Result<geo_types::LineString<f64>> {
     let n_points = unsafe { sfcgal_linestring_num_points(sfcgal_geom) };
-    let mut v_points = Vec::with_capacity(n_points);
+    let mut v_points = Vec::with_capacity(n_points as usize);
     for i in 0..n_points {
         let pt_sfcgal = unsafe { sfcgal_linestring_point_n(sfcgal_geom, i) };
         check_null_geom(pt_sfcgal)?;

--- a/src/conversion/geotypes.rs
+++ b/src/conversion/geotypes.rs
@@ -1,6 +1,7 @@
-use crate::conversion::coords::{CoordSeq, CoordType, ToSFCGALGeom};
 use crate::{
-    utils::check_null_geom, GeomType, Point2d, Result, SFCGeometry, ToCoordinates, ToSFCGAL,
+    conversion::coords::{CoordSeq, CoordType, ToSFCGALGeom},
+    utils::check_null_geom,
+    GeomType, Point2d, Result, SFCGeometry, ToCoordinates, ToSFCGAL,
 };
 use anyhow::Error;
 use sfcgal_sys::{

--- a/src/conversion/geotypes.rs
+++ b/src/conversion/geotypes.rs
@@ -2,7 +2,7 @@ use crate::conversion::coords::{CoordSeq, CoordType, ToSFCGALGeom};
 use crate::{
     utils::check_null_geom, GeomType, Point2d, Result, SFCGeometry, ToCoordinates, ToSFCGAL,
 };
-use failure::Error;
+use anyhow::Error;
 use sfcgal_sys::{
     sfcgal_geometry_collection_add_geometry, sfcgal_geometry_collection_create,
     sfcgal_geometry_collection_geometry_n, sfcgal_geometry_collection_num_geometries,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::utils::_string;
-use failure::Error;
+use anyhow::Error;
 use sfcgal_sys::w_sfcgal_get_last_error;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,8 +1,9 @@
-use crate::conversion::{CoordSeq, CoordType, ToSFCGALGeom};
-use crate::errors::get_last_error;
-use crate::utils::{_c_string_with_size, _string, check_computed_value, check_predicate};
-use crate::{Result, ToSFCGAL};
-use libc::c_char;
+use crate::{
+    conversion::{CoordSeq, CoordType, ToSFCGALGeom},
+    errors::get_last_error,
+    utils::{_c_string_with_size, _string, check_computed_value, check_predicate},
+    {Result, ToSFCGAL},
+};
 use num_traits::FromPrimitive;
 use sfcgal_sys::{
     initialize, sfcgal_geometry_approximate_medial_axis, sfcgal_geometry_area,
@@ -22,9 +23,7 @@ use sfcgal_sys::{
     sfcgal_geometry_union_3d, sfcgal_geometry_volume, sfcgal_io_read_wkt,
     sfcgal_multi_linestring_create, sfcgal_multi_point_create, sfcgal_multi_polygon_create,
 };
-use std::ffi::CString;
-use std::mem::MaybeUninit;
-use std::ptr::NonNull;
+use std::{ffi::CString, mem::MaybeUninit, os::raw::c_char, ptr::NonNull};
 
 /// SFCGAL Geometry types.
 ///

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -21,7 +21,7 @@ use sfcgal_sys::{
     sfcgal_geometry_straight_skeleton_distance_in_m, sfcgal_geometry_t, sfcgal_geometry_tesselate,
     sfcgal_geometry_triangulate_2dz, sfcgal_geometry_type_id, sfcgal_geometry_union,
     sfcgal_geometry_union_3d, sfcgal_geometry_volume, sfcgal_io_read_wkt,
-    sfcgal_multi_linestring_create, sfcgal_multi_point_create, sfcgal_multi_polygon_create,
+    sfcgal_multi_linestring_create, sfcgal_multi_point_create, sfcgal_multi_polygon_create, size_t,
 };
 use std::{ffi::CString, mem::MaybeUninit, os::raw::c_char, ptr::NonNull};
 
@@ -110,7 +110,7 @@ impl SFCGeometry {
     pub fn new(wkt: &str) -> Result<SFCGeometry> {
         initialize();
         let c_str = CString::new(wkt)?;
-        let obj = unsafe { sfcgal_io_read_wkt(c_str.as_ptr(), wkt.len()) };
+        let obj = unsafe { sfcgal_io_read_wkt(c_str.as_ptr(), wkt.len() as size_t) };
         unsafe { SFCGeometry::new_from_raw(obj, true) }
     }
 
@@ -140,7 +140,7 @@ impl SFCGeometry {
     /// ([C API reference](http://oslandia.github.io/SFCGAL/doxygen/group__capi.html#ga3bc1954e3c034b60f0faff5e8227c398))
     pub fn to_wkt(&self) -> Result<String> {
         let mut ptr = MaybeUninit::<*mut c_char>::uninit();
-        let mut length: usize = 0;
+        let mut length: size_t = 0;
         unsafe {
             sfcgal_geometry_as_text(self.c_geom.as_ref(), ptr.as_mut_ptr(), &mut length);
             Ok(_c_string_with_size(ptr.assume_init(), length))
@@ -152,7 +152,7 @@ impl SFCGeometry {
     /// ([C API reference](http://oslandia.github.io/SFCGAL/doxygen/group__capi.html#gaaf23f2c95fd48810beb37d07a9652253))
     pub fn to_wkt_decim(&self, nb_decim: i32) -> Result<String> {
         let mut ptr = MaybeUninit::<*mut c_char>::uninit();
-        let mut length: usize = 0;
+        let mut length: size_t = 0;
         unsafe {
             sfcgal_geometry_as_text_decim(
                 self.c_geom.as_ref(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! ```
 
 #[macro_use]
-extern crate failure;
+extern crate anyhow;
 #[macro_use]
 extern crate enum_primitive_derive;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,10 @@
 
 #[macro_use]
 extern crate failure;
-extern crate libc;
-extern crate sfcgal_sys;
 #[macro_use]
 extern crate enum_primitive_derive;
-extern crate geo_types;
-extern crate num_traits;
 #[macro_use]
 extern crate approx;
-extern crate geojson;
 
 use sfcgal_sys::sfcgal_version;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,9 +40,8 @@ pub(crate) fn check_computed_value(val: f64) -> Result<f64> {
 // (as it seems to not always end with a null byte)
 // from the pointer to uninitialized memory with give
 // to it earlier.
-pub(crate) fn _c_string_with_size(raw_ptr: *mut c_char, size: usize) -> String {
-    let slice: &[u8] =
-        unsafe { &*(std::slice::from_raw_parts(raw_ptr, size) as *const [i8] as *const [u8]) };
+pub(crate) fn _c_string_with_size(raw_ptr: *const c_char, size: usize) -> String {
+    let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_ptr as *const u8, size) };
     let res = std::str::from_utf8(slice).unwrap().to_string();
     unsafe { libc::free(raw_ptr as *mut libc::c_void) };
     res

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,7 +41,7 @@ pub(crate) fn check_computed_value(val: f64) -> Result<f64> {
 // (as it seems to not always end with a null byte)
 // from the pointer to uninitialized memory with give
 // to it earlier.
-pub(crate) fn _c_string_with_size(raw_ptr: *mut i8, size: usize) -> String {
+pub(crate) fn _c_string_with_size(raw_ptr: *mut c_char, size: usize) -> String {
     let slice: &[u8] =
         unsafe { &*(std::slice::from_raw_parts(raw_ptr, size) as *const [i8] as *const [u8]) };
     let res = std::str::from_utf8(slice).unwrap().to_string();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use approx::AbsDiff;
-use sfcgal_sys::sfcgal_geometry_t;
+use sfcgal_sys::{sfcgal_geometry_t, size_t};
 use std::{ffi::CStr, os::raw::c_char};
 
 use crate::errors::get_last_error;
@@ -40,8 +40,8 @@ pub(crate) fn check_computed_value(val: f64) -> Result<f64> {
 // (as it seems to not always end with a null byte)
 // from the pointer to uninitialized memory with give
 // to it earlier.
-pub(crate) fn _c_string_with_size(raw_ptr: *const c_char, size: usize) -> String {
-    let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_ptr as *const u8, size) };
+pub(crate) fn _c_string_with_size(raw_ptr: *const c_char, size: size_t) -> String {
+    let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_ptr as *const u8, size as usize) };
     let res = std::str::from_utf8(slice).unwrap().to_string();
     unsafe { libc::free(raw_ptr as *mut libc::c_void) };
     res

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use approx::AbsDiff;
-use libc::c_char;
 use sfcgal_sys::sfcgal_geometry_t;
-use std::ffi::CStr;
+use std::{ffi::CStr, os::raw::c_char};
 
 use crate::errors::get_last_error;
 use crate::Result;


### PR DESCRIPTION
- Use ffi types, `size_t`, `c_char`, etc
- Replace deprecated failure with anyhow
- rustfmt
- Use less restrict `x.y` version number in `Cargo.toml`, which is suggested for lib crates
- Replace deprecated `uninitialized()` with `MaybeUninit`
- Tidy `use ...` statements.
- Other code simplifications