### PR TITLE
Make `geo-types` and `geojson` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ geojson = { version = ">= 0.19, <= 0.24.1", optional = true }
 [features]
 default = ["geo-types", "geojson"]
 geo-types = ["dep:geo-types"]
-geojson = ["geo-types", "dep:geojson"]
+geojson = ["dep:geojson"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,34 @@
 [package]
 name = "sfcgal"
-version = "0.8.1"
+version = "0.8.2"
+edition = "2021"
+
 authors = ["Matthieu Viry <matthieu.viry@cnrs.fr>"]
 license = "MIT/Apache-2.0"
-edition = "2021"
 description = """
 High-level bindings to SFCGAL and conversion from/to other geometry libraries.
 """
+
 readme = "README.md"
 homepage = "https://github.com/mthh/sfcgal-rs"
 repository = "https://github.com/mthh/sfcgal-rs"
+documentation = "https://mthh.github.io/sfcgal-rs/sfcgal/"
+
 keywords = ["geometry", "geospatial", "gis", "sfcgal"]
 categories = ["algorithms", "api-bindings"]
-documentation = "https://mthh.github.io/sfcgal-rs/sfcgal/"
 
 [dependencies]
 sfcgal-sys = "0.8.0"
 anyhow = "1.0"
 libc = "0.2"
-geo-types = "0.7"
-enum-primitive-derive = "0.3"
 num-traits = "0.2"
+enum-primitive-derive = "0.3"
 approx = "0.5"
-geojson = ">= 0.19, <= 0.24.1"
+
+geo-types = { version = "0.7", optional = true }
+geojson = { version = ">= 0.19, <= 0.24.1", optional = true }
+
+[features]
+default = ["geo-types", "geojson"]
+geo-types = ["dep:geo-types"]
+geojson = ["geo-types", "dep:geojson"]

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -1,8 +1,15 @@
 #[macro_use]
 mod macros;
+
 mod coords;
-mod geojson;
-mod geotypes;
-pub use self::geojson::*;
 pub use coords::*;
+
+#[cfg(feature = "geojson")]
+mod geojson;
+#[cfg(feature = "geojson")]
+pub use self::geojson::*;
+
+#[cfg(feature = "geo-types")]
+mod geotypes;
+#[cfg(feature = "geo-types")]
 pub use geotypes::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,10 @@ mod geometry;
 mod utils;
 
 pub use conversion::CoordSeq;
-#[cfg(feature = "geojson")]
-pub use conversion::{FromGeoJSON, ToGeoJSON};
 #[cfg(feature = "geo-types")]
 pub use conversion::TryInto;
+#[cfg(feature = "geojson")]
+pub use conversion::{FromGeoJSON, ToGeoJSON};
 pub use errors::Result;
 pub use geometry::{BufferType, GeomType, Orientation, SFCGeometry};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,11 @@ mod errors;
 mod geometry;
 mod utils;
 
-pub use conversion::{CoordSeq, FromGeoJSON, ToGeoJSON, TryInto};
+pub use conversion::CoordSeq;
+#[cfg(feature = "geojson")]
+pub use conversion::{FromGeoJSON, ToGeoJSON};
+#[cfg(feature = "geo-types")]
+pub use conversion::TryInto;
 pub use errors::Result;
 pub use geometry::{BufferType, GeomType, Orientation, SFCGeometry};
 
@@ -97,8 +101,7 @@ mod tests {
     use super::version;
 
     #[test]
-
     fn display_version() {
-        assert!(version().contains("2.0."));
+        assert!(version().starts_with("2."));
     }
 }


### PR DESCRIPTION
This patch makes `geo-types` and `geojson` optional so the user can reduce dependencies. They are still enabled by default to prevent breaking changes.