### PR TITLE
Updated Missing functions

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,7 +62,7 @@ pub(crate) fn check_nan_value(val: f64) -> Result<f64> {
 // (as it seems to not always end with a null byte)
 // from the pointer to uninitialized memory with give
 // to it earlier.
-pub(crate) fn _c_string_with_size(raw_ptr: *const c_char, size: usize) -> String {
+pub(crate) fn c_string_with_size(raw_ptr: *const c_char, size: usize) -> String {
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_ptr as *const u8, size) };
 
     let res = std::str::from_utf8(slice).unwrap().to_string();


### PR DESCRIPTION
Updated the missing functions since last C api update.
I didn't touch sfcgal-sys.

I also marked some functions as deprecated, to follow the sfcgal guideline.

To ease the review, I separated the newly added sfcgal_ function in their own block.
The rust methods were grouped below the "For review" to ease the double check.

Some new functions were not decorated with pre checks: this is intentional because it would require more work. I may do that later.

Please feel free to point errors I could make. I will correct them. :)